### PR TITLE
Migrate plugin to Rack V2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "EH_modules",
   "name": "FV-1.emu",
-  "version": "1.0.5",
+  "version": "2.0.5",
   "license": "GPL-3.0-only",
   "author": "Eduard Heidt",
   "authorEmail": "",


### PR DESCRIPTION
Migration to V2 required a few syntax changes, mostly changes from accessing member attributes to getter functions in V2.
Other changes:
- The module specified a font for the display panel, but never loaded it
- V2 rewrote the code for LedDisplay, so the Debug Panel had to be re-written for this